### PR TITLE
Fix macOS build: missing header and struct field name

### DIFF
--- a/nfq2/helpers.c
+++ b/nfq2/helpers.c
@@ -11,6 +11,9 @@
 #include <libgen.h>
 #include <errno.h>
 #include <sys/param.h>
+#ifdef __APPLE__
+#include <sys/random.h>
+#endif
 
 #define UNIQ_SORT \
 { \

--- a/nfq2/lua.c
+++ b/nfq2/lua.c
@@ -3646,7 +3646,11 @@ static int luacall_stat(lua_State *L)
 		lua_pushf_lint(L,"dev", st.st_dev);
 		lua_pushf_lint(L,"inode", st.st_ino);
 		lua_pushf_lint(L,"size", st.st_size);
+#ifdef __APPLE__
+		lua_pushf_number(L,"mtime", st.st_mtimespec.tv_sec + st.st_mtimespec.tv_nsec/1000000000.);
+#else
 		lua_pushf_number(L,"mtime", st.st_mtim.tv_sec + st.st_mtim.tv_nsec/1000000000.);
+#endif
 
 		const char *ftype;
 		switch(st.st_mode & S_IFMT)


### PR DESCRIPTION
## Summary
- `nfq2/helpers.c`: add `#include <sys/random.h>` on `__APPLE__` — macOS needs this header for `getrandom()` (not exposed via `<stdlib.h>`)
- `nfq2/lua.c`: use `st_mtimespec` instead of `st_mtim` on `__APPLE__` — macOS `struct stat` uses a different field name

Both changes are guarded by `#ifdef __APPLE__` and do not affect Linux, Windows, or any other platform.

## Test plan
- [x] Builds and runs correctly on macOS (arm64, AppleClang 17)
- [x] No changes to non-Apple platforms — `#ifdef __APPLE__` guards only

🤖 Generated with [Claude Code](https://claude.com/claude-code)