### PR TITLE
nfqws2: fix building on e2k

### DIFF
--- a/nfq2/sec.h
+++ b/nfq2/sec.h
@@ -95,6 +95,10 @@ bool dropcaps(void);
 
 # define ARCH_NR AUDIT_ARCH_LOONGARCH64
 
+#elif defined(__e2k__)
+
+# define ARCH_NR	AUDIT_ARCH_E2K
+
 #else
 
 # error "Platform does not support seccomp filter yet"


### PR DESCRIPTION
While E2K isn't in Linux mainline yet, there is published source code by the vendor: https://github.com/OpenE2K/linux, and their port supports seccomp.

So the whole support is single line change.

Identical to https://github.com/bol-van/zapret/pull/2096.