### PR TITLE
Restore firewall on keenetic devices.

### DIFF
--- a/init.d/sysv/ndm/netfilter.d/000-zapret2.sh
+++ b/init.d/sysv/ndm/netfilter.d/000-zapret2.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+[ "$table" != "mangle" ] && [ "$table" != "nat" ] && exit 0
+[ -f /var/run/zapret2.pid ] && /opt/zapret2/init.d/sysv/zapret2 restart-fw
+exit 0

--- a/init.d/sysv/zapret2
+++ b/init.d/sysv/zapret2
@@ -19,11 +19,13 @@ do_start()
 {
 	zapret_run_daemons
 	[ "$INIT_APPLY_FW" != "1" ] || { zapret_apply_firewall; }
+	touch /var/run/zapret2.pid
 }
 do_stop()
 {
 	zapret_stop_daemons
 	[ "$INIT_APPLY_FW" != "1" ] || zapret_unapply_firewall
+	rm -f /var/run/zapret2.pid
 }
 
 case "$1" in


### PR DESCRIPTION
On a keenetic firewall rules reloaded by firmware each time device send dhcp or update upnp rules.
To restore zapret firewall we need to place ./init.d/sysv/ndm/netfilter.d/000-zapret2.sh to /opt/etc/ndm/netfilter.d/000-zapret2.sh
Then we need to inform if zapret daemon started or not, creating file flag in ramfs: /var/run/zapret2.pid, or we can't use ./blockcheck2.sh, since ndm will restart firewall by dhcp or upnp event.