### PR TITLE
Ограничить размер conntrack и IP-кеша

### DIFF
--- a/nfq2/conntrack.c
+++ b/nfq2/conntrack.c
@@ -60,12 +60,13 @@ void ConntrackPoolDestroy(t_conntrack *p)
 	ConntrackPoolDestroyPool(&p->pool);
 }
 
-void ConntrackPoolInit(t_conntrack *p, time_t purge_interval, uint32_t timeout_syn, uint32_t timeout_established, uint32_t timeout_fin, uint32_t timeout_udp)
+void ConntrackPoolInit(t_conntrack *p, time_t purge_interval, uint32_t timeout_syn, uint32_t timeout_established, uint32_t timeout_fin, uint32_t timeout_udp, size_t max_entries)
 {
 	p->timeout_syn = timeout_syn;
 	p->timeout_established = timeout_established;
 	p->timeout_fin = timeout_fin;
 	p->timeout_udp = timeout_udp;
+	p->max_entries = max_entries;
 	p->t_purge_interval = purge_interval;
 	p->t_last_purge = boottime();
 	p->pool = NULL;
@@ -253,7 +254,7 @@ bool ConntrackPoolDoubleSearch(t_conntrack *p, const struct dissect *dis, t_ctra
 	return ConntrackPoolDoubleSearchPool(&p->pool, dis, ctrack, bReverse);
 }
 
-static bool ConntrackPoolFeedPool(t_conntrack_pool **pp, const struct dissect *dis, t_ctrack **ctrack, bool *bReverse)
+static bool ConntrackPoolFeedPool(t_conntrack *p, t_conntrack_pool **pp, const struct dissect *dis, t_ctrack **ctrack, bool *bReverse)
 {
 	t_conn conn, connswp;
 	t_conntrack_pool *ctr;
@@ -278,6 +279,8 @@ static bool ConntrackPoolFeedPool(t_conntrack_pool **pp, const struct dissect *d
 	b_rev = dis->tcp && tcp_synack_segment(dis->tcp);
 	if ((dis->tcp && tcp_syn_segment(dis->tcp)) || b_rev || dis->udp)
 	{
+		if (p->max_entries && HASH_COUNT(*pp) >= p->max_entries)
+			return false;
 		if ((ctr = ConntrackNew(pp, b_rev ? &connswp : &conn)))
 		{
 			ConntrackFeedPacket(&ctr->track, b_rev, dis);
@@ -293,7 +296,7 @@ ok:
 }
 bool ConntrackPoolFeed(t_conntrack *p, const struct dissect *dis, t_ctrack **ctrack, bool *bReverse)
 {
-	return ConntrackPoolFeedPool(&p->pool, dis, ctrack, bReverse);
+	return ConntrackPoolFeedPool(p, &p->pool, dis, ctrack, bReverse);
 }
 
 static bool ConntrackPoolDropPool(t_conntrack_pool **pp, const struct dissect *dis)

--- a/nfq2/conntrack.h
+++ b/nfq2/conntrack.h
@@ -95,11 +95,12 @@ typedef struct
 {
 	// inactivity time to purge an entry in each connection state
 	uint32_t timeout_syn,timeout_established,timeout_fin,timeout_udp;
+	size_t max_entries;
 	time_t t_purge_interval, t_last_purge;
 	t_conntrack_pool *pool;
 } t_conntrack;
 
-void ConntrackPoolInit(t_conntrack *p, time_t purge_interval, uint32_t timeout_syn, uint32_t timeout_established, uint32_t timeout_fin, uint32_t timeout_udp);
+void ConntrackPoolInit(t_conntrack *p, time_t purge_interval, uint32_t timeout_syn, uint32_t timeout_established, uint32_t timeout_fin, uint32_t timeout_udp, size_t max_entries);
 void ConntrackPoolDestroy(t_conntrack *p);
 bool ConntrackPoolFeed(t_conntrack *p, const struct dissect *dis, t_ctrack **ctrack, bool *bReverse);
 // do not create, do not update. only find existing

--- a/nfq2/nfqws.c
+++ b/nfq2/nfqws.c
@@ -1836,10 +1836,12 @@ static void exithelp(void)
 		" --sockarg=<int|0xHEX>\t\t\t\t\t; override sockarg (SO_USER_COOKIE) for generated packets. default = 0x%08X (%u)\n"
 #endif
 		" --ctrack-timeouts=S:E:F[:U]\t\t\t\t; internal conntrack timeouts for TCP SYN, ESTABLISHED, FIN stages, UDP timeout. default %u:%u:%u:%u\n"
+		" --ctrack-max=<int>\t\t\t\t\t; maximum internal conntrack entries. 0 = unlimited. default %u\n"
 		" --ctrack-disable=[0|1]\t\t\t\t\t; 1 or no argument disables conntrack\n"
 		" --payload-disable=[type[,type]]\t\t\t; do not discover these payload types. for available payload types see '--payload'. disable all if no argument.\n"
 		" --server=[0|1]\t\t\t\t\t\t; change multiple aspects of src/dst ip/port handling for incoming connections\n"
 		" --ipcache-lifetime=<int>\t\t\t\t; time in seconds to keep cached hop count and domain name (default %u). 0 = no expiration\n"
+		" --ipcache-max=<int>\t\t\t\t\t; maximum IP-cache entries. 0 = unlimited. default %u\n"
 		" --ipcache-hostname=[0|1]\t\t\t\t; 1 or no argument enables ip->hostname caching\n"
 		" --reasm-disable=[type[,type]]\t\t\t\t; disable reasm for these L7 payloads : tls_client_hello quic_initial . if no argument - disable all reasm.\n"
 #ifdef __CYGWIN__
@@ -1916,7 +1918,9 @@ static void exithelp(void)
 		DPI_DESYNC_FWMARK_DEFAULT,DPI_DESYNC_FWMARK_DEFAULT,
 #endif
 		CTRACK_T_SYN, CTRACK_T_EST, CTRACK_T_FIN, CTRACK_T_UDP,
+		CTRACK_MAX_ENTRIES,
 		IPCACHE_LIFETIME,
+		IPCACHE_MAX_ENTRIES,
 		LUA_GC_INTERVAL,
 		all_protos,
 		HOSTLIST_AUTO_FAIL_THRESHOLD_DEFAULT, HOSTLIST_AUTO_FAIL_TIME_DEFAULT,
@@ -1993,10 +1997,12 @@ enum opt_indices {
 	IDX_UID,
 #endif
 	IDX_CTRACK_TIMEOUTS,
+	IDX_CTRACK_MAX,
 	IDX_CTRACK_DISABLE,
 	IDX_PAYLOAD_DISABLE,
 	IDX_SERVER,
 	IDX_IPCACHE_LIFETIME,
+	IDX_IPCACHE_MAX,
 	IDX_IPCACHE_HOSTNAME,
 	IDX_REASM_DISABLE,
 #ifdef __linux__
@@ -2098,10 +2104,12 @@ static const struct option long_options[] = {
 	[IDX_UID] = {"uid", required_argument, 0, 0},
 #endif
 	[IDX_CTRACK_TIMEOUTS] = {"ctrack-timeouts", required_argument, 0, 0},
+	[IDX_CTRACK_MAX] = {"ctrack-max", required_argument, 0, 0},
 	[IDX_CTRACK_DISABLE] = {"ctrack-disable", optional_argument, 0, 0},
 	[IDX_PAYLOAD_DISABLE] = {"payload-disable", optional_argument, 0, 0},
 	[IDX_SERVER] = {"server", optional_argument, 0, 0},
 	[IDX_IPCACHE_LIFETIME] = {"ipcache-lifetime", required_argument, 0, 0},
+	[IDX_IPCACHE_MAX] = {"ipcache-max", required_argument, 0, 0},
 	[IDX_IPCACHE_HOSTNAME] = {"ipcache-hostname", optional_argument, 0, 0},
 	[IDX_REASM_DISABLE] = {"reasm-disable", optional_argument, 0, 0},
 #ifdef __linux__
@@ -2466,6 +2474,13 @@ int main(int argc, char **argv)
 				exit_clean(1);
 			}
 			break;
+		case IDX_CTRACK_MAX:
+			if (sscanf(optarg, "%u", &params.ctrack_max_entries) != 1)
+			{
+				DLOG_ERR("invalid ctrack max entries\n");
+				exit_clean(1);
+			}
+			break;
 		case IDX_CTRACK_DISABLE:
 			params.ctrack_disable = !optarg || atoi(optarg);
 			break;
@@ -2476,6 +2491,13 @@ int main(int argc, char **argv)
 			if (sscanf(optarg, "%u", &params.ipcache_lifetime) != 1)
 			{
 				DLOG_ERR("invalid ipcache-lifetime value\n");
+				exit_clean(1);
+			}
+			break;
+		case IDX_IPCACHE_MAX:
+			if (sscanf(optarg, "%zu", &params.ipcache.max_entries) != 1)
+			{
+				DLOG_ERR("invalid ipcache max entries\n");
 				exit_clean(1);
 			}
 			break;
@@ -3326,7 +3348,7 @@ int main(int argc, char **argv)
 	else
 	{
 		DLOG("initializing conntrack with timeouts tcp=%u:%u:%u udp=%u\n", params.ctrack_t_syn, params.ctrack_t_est, params.ctrack_t_fin, params.ctrack_t_udp);
-		ConntrackPoolInit(&params.conntrack, 10, params.ctrack_t_syn, params.ctrack_t_est, params.ctrack_t_fin, params.ctrack_t_udp);
+		ConntrackPoolInit(&params.conntrack, 10, params.ctrack_t_syn, params.ctrack_t_est, params.ctrack_t_fin, params.ctrack_t_udp, params.ctrack_max_entries);
 	}
 	DLOG("ipcache lifetime %us\n", params.ipcache_lifetime);
 

--- a/nfq2/params.c
+++ b/nfq2/params.c
@@ -587,7 +587,9 @@ void init_params(struct params_s *params)
 	params->ctrack_t_est = CTRACK_T_EST;
 	params->ctrack_t_fin = CTRACK_T_FIN;
 	params->ctrack_t_udp = CTRACK_T_UDP;
+	params->ctrack_max_entries = CTRACK_MAX_ENTRIES;
 	params->ipcache_lifetime = IPCACHE_LIFETIME;
+	params->ipcache.max_entries = IPCACHE_MAX_ENTRIES;
 	params->lua_gc = LUA_GC_INTERVAL*1000;
 
 	LIST_INIT(&params->hostlists);

--- a/nfq2/params.h
+++ b/nfq2/params.h
@@ -36,6 +36,8 @@
 #define HOSTLIST_AUTO_UDP_IN			1
 
 #define IPCACHE_LIFETIME		7200
+#define CTRACK_MAX_ENTRIES		8192
+#define IPCACHE_MAX_ENTRIES		16384
 
 #define MAX_GIDS 64
 
@@ -176,6 +178,7 @@ struct params_s
 	struct blob_collection_head blobs;
 
 	unsigned int ctrack_t_syn, ctrack_t_est, ctrack_t_fin, ctrack_t_udp;
+	unsigned int ctrack_max_entries;
 	t_conntrack conntrack;
 	bool ctrack_disable, server;
 

--- a/nfq2/pools.c
+++ b/nfq2/pools.c
@@ -1061,6 +1061,38 @@ static ip_cache6 *ipcache6Add(ip_cache6 **ipcache, const struct in6_addr *a, con
 
 	return entry;
 }
+
+static bool ipcache_evict_oldest(ip_cache *ipcache)
+{
+	ip_cache4 *entry4, *oldest4 = NULL, *tmp4;
+	ip_cache6 *entry6, *oldest6 = NULL, *tmp6;
+
+	HASH_ITER(hh, ipcache->ipcache4, entry4, tmp4)
+	{
+		if (!oldest4 || entry4->data.last < oldest4->data.last)
+			oldest4 = entry4;
+	}
+	HASH_ITER(hh, ipcache->ipcache6, entry6, tmp6)
+	{
+		if (!oldest6 || entry6->data.last < oldest6->data.last)
+			oldest6 = entry6;
+	}
+	if (oldest4 && (!oldest6 || oldest4->data.last <= oldest6->data.last))
+	{
+		HASH_DEL(ipcache->ipcache4, oldest4);
+		ipcache_item_destroy(&oldest4->data);
+		free(oldest4);
+		return true;
+	}
+	if (oldest6)
+	{
+		HASH_DEL(ipcache->ipcache6, oldest6);
+		ipcache_item_destroy(&oldest6->data);
+		free(oldest6);
+		return true;
+	}
+	return false;
+}
 static void ipcache6Print(ip_cache6 *ipcache)
 {
 	char s_ip[INET6_ADDRSTRLEN];
@@ -1109,6 +1141,13 @@ ip_cache_item *ipcacheTouch(ip_cache *ipcache, const struct in_addr *a4, const s
 	ip_cache6 *ipcache6;
 	if (a4)
 	{
+		if ((ipcache4 = ipcache4Find(ipcache->ipcache4,a4,iface)))
+		{
+			ipcache_item_touch(&ipcache4->data);
+			return &ipcache4->data;
+		}
+	while (ipcache->max_entries && ((size_t)HASH_COUNT(ipcache->ipcache4) + HASH_COUNT(ipcache->ipcache6)) >= ipcache->max_entries)
+			if (!ipcache_evict_oldest(ipcache)) return NULL;
 		if ((ipcache4 = ipcache4Add(&ipcache->ipcache4,a4,iface)))
 		{
 			ipcache_item_touch(&ipcache4->data);
@@ -1117,6 +1156,13 @@ ip_cache_item *ipcacheTouch(ip_cache *ipcache, const struct in_addr *a4, const s
 	}
 	else if (a6)
 	{
+		if ((ipcache6 = ipcache6Find(ipcache->ipcache6,a6,iface)))
+		{
+			ipcache_item_touch(&ipcache6->data);
+			return &ipcache6->data;
+		}
+	while (ipcache->max_entries && ((size_t)HASH_COUNT(ipcache->ipcache4) + HASH_COUNT(ipcache->ipcache6)) >= ipcache->max_entries)
+			if (!ipcache_evict_oldest(ipcache)) return NULL;
 		if ((ipcache6 = ipcache6Add(&ipcache->ipcache6,a6,iface)))
 		{
 			ipcache_item_touch(&ipcache6->data);
@@ -1173,4 +1219,3 @@ void ipcachePurgeRateLimited(ip_cache *ipcache, time_t lifetime)
 		ipcache_purge_prev = now;
 	}
 }
-

--- a/nfq2/pools.h
+++ b/nfq2/pools.h
@@ -290,6 +290,7 @@ typedef struct ip_cache
 {
 	ip_cache4 *ipcache4;
 	ip_cache6 *ipcache6;
+	size_t max_entries;
 } ip_cache;
 
 ip_cache_item *ipcacheTouch(ip_cache *ipcache, const struct in_addr *a4, const struct in6_addr *a6, const char *iface);


### PR DESCRIPTION
## Что изменено

- Добавлен лимит internal conntrack: по умолчанию 8192 записи.
- Добавлен лимит IP-кеша: по умолчанию 16384 записи.
- Добавлены параметры `--ctrack-max` и `--ipcache-max`.
  Значение `0` отключает соответствующий лимит.
- При заполнении conntrack новые записи не создаются.
- При заполнении IP-кеша удаляется самая старая запись, затем добавляется новая.

## Причина

Conntrack и IP-кеш создавали записи на основе сетевого трафика без верхней границы.
Записи существовали до очистки по timeout, поэтому рост числа уникальных потоков или адресов приводил к неограниченному росту памяти.

## Влияние

Лимиты защищают процесс от неограниченного накопления состояния при большом числе уникальных сетевых входов. При заполненном conntrack новый поток обрабатывается без внутреннего состояния; IP-кеш продолжает хранить наиболее свежие записи.

## Проверка

Проверено локально с ASan/UBSan и на OpenWrt 24.10.1, aarch64_cortex-a53.

- 50 000 уникальных UDP-потоков при лимите 1000 оставляют ровно 1000 conntrack-записей.
- 50 000 уникальных IP-адресов при лимите 1000 оставляют ровно 1000 IP-cache записей; самая ранняя запись вытесняется, последняя сохраняется.
- `git diff --check` завершился успешно.
