### PR TITLE
Fixed the double-free reports in [nfqws.c (line 1118)

### DIFF
--- a/nfq2/nfqws.c
+++ b/nfq2/nfqws.c
@@ -1117,7 +1117,7 @@ static char* item_name(char **str)
 
 static struct blob_item *load_blob_to_collection(const char *filename, struct blob_collection_head *blobs, size_t max_size, size_t size_reserve)
 {
-	struct blob_item *blob = blob_collection_add(blobs);
+	struct blob_item *blob;
 	uint8_t *p;
 	char *name;
 
@@ -1159,6 +1159,7 @@ static struct blob_item *load_blob_to_collection(const char *filename, struct bl
 		free(name);
 		exit_clean(1);
 	}
+	blob = blob_collection_add(blobs);
 	if (!blob || (!(blob->data = malloc(max_size + size_reserve))))
 	{
 		free(name);


### PR DESCRIPTION
blob_collection_add() now occurs only after name/file validation and duplicate-name checks. This prevents exit_clean() from traversing a partially registered blob while name is being freed locally.

nfq2/nfqws.c:1140:4: error: Memory pointed to by 'name' is freed twice. [doubleFree]
nfq2/nfqws.c:1148:5: error: Memory pointed to by 'name' is freed twice. [doubleFree]
nfq2/nfqws.c:1159:3: error: Memory pointed to by 'name' is freed twice. [doubleFree]
nfq2/nfqws.c:1164:3: error: Memory pointed to by 'name' is freed twice. [doubleFree]