### PR TITLE
fix: libluajit2-5.1-dev is not available

### DIFF
--- a/docs/compile/build_howto_unix.txt
+++ b/docs/compile/build_howto_unix.txt
@@ -1,6 +1,6 @@
 * debian,ubuntu :
 
-apt install make gcc zlib1g-dev libcap-dev libnetfilter-queue-dev libmnl-dev libsystemd-dev libluajit2-5.1-dev
+apt install make gcc zlib1g-dev libcap-dev libnetfilter-queue-dev libmnl-dev libsystemd-dev libluajit-5.1-dev
 make -C /opt/zapret2 systemd
 
 * fedora, rhel, centos, alma


### PR DESCRIPTION
`libluajit2-5.1-dev` fails to install on `Ubuntu 26.04`.

```
root@845068:~# apt install libluajit2-5.1-dev
```
```
Package libluajit2-5.1-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libluajit-5.1-dev
 

Error: Package 'libluajit2-5.1-dev' has no installation candidate
```