### PR TITLE
Fix -Wcast-qual and -Wlogical-op-parentheses warnings

### DIFF
--- a/nfq2/checksum.c
+++ b/nfq2/checksum.c
@@ -72,13 +72,13 @@ static uint16_t do_csum(const uint8_t *buff, size_t len)
 			}
 			if (len & 4)
 			{
-				result += *(uint32_t *)buff;
+				result += *(const uint32_t *)buff;
 				buff += 4;
 			}
 		}
 		if (len & 2)
 		{
-			result += *(uint16_t *)buff;
+			result += *(const uint16_t *)buff;
 			buff += 2;
 		}
 	}
@@ -115,8 +115,8 @@ void ip4_fix_checksum(struct ip *ip)
 uint16_t csum_ipv6_magic(const void *saddr, const void *daddr, size_t len, uint8_t proto, uint16_t sum)
 {
 	uint64_t a = (uint64_t)sum + htonl(len + proto) +
-				 *(uint32_t *)saddr + *((uint32_t *)saddr + 1) + *((uint32_t *)saddr + 2) + *((uint32_t *)saddr + 3) +
-				 *(uint32_t *)daddr + *((uint32_t *)daddr + 1) + *((uint32_t *)daddr + 2) + *((uint32_t *)daddr + 3);
+				 *(const uint32_t *)saddr + *((const uint32_t *)saddr + 1) + *((const uint32_t *)saddr + 2) + *((const uint32_t *)saddr + 3) +
+				 *(const uint32_t *)daddr + *((const uint32_t *)daddr + 1) + *((const uint32_t *)daddr + 2) + *((const uint32_t *)daddr + 3);
 	return ~from64to16(a);
 }
 

--- a/nfq2/desync.c
+++ b/nfq2/desync.c
@@ -614,8 +614,8 @@ static uint8_t ct_new_postnat_fix(const t_ctrack *ctrack, const struct dissect *
 	// if used in postnat chain, dropping initial packet will cause conntrack connection teardown
 	// so we need to workaround this.
 	// SYN and SYN,ACK checks are for conntrack-less mode
-	if (ctrack && (params.server ? ctrack->pos.server.pcounter : ctrack->pos.client.pcounter) == 1 ||
-		!ctrack && dis->tcp && (tcp_syn_segment(dis->tcp) || tcp_synack_segment(dis->tcp)))
+	if ((ctrack && (params.server ? ctrack->pos.server.pcounter : ctrack->pos.client.pcounter) == 1) ||
+		(!ctrack && dis->tcp && (tcp_syn_segment(dis->tcp) || tcp_synack_segment(dis->tcp))))
 	{
 		if (dis->len_pkt > *len_mod_pkt)
 			DLOG_ERR("linux postnat conntrack workaround cannot be applied\n");
@@ -687,7 +687,7 @@ static bool check_pos_to(const t_ctrack_position *pos, const struct packet_range
 		if (pos)
 		{
 			ps = pos_get(pos, range->to.mode);
-			return (ps < range->to.pos) || !range->upper_cutoff && (ps == range->to.pos);
+			return (ps < range->to.pos) || (!range->upper_cutoff && (ps == range->to.pos));
 		}
 		else
 			return false;

--- a/nfq2/helpers.c
+++ b/nfq2/helpers.c
@@ -35,7 +35,7 @@ int unique_ssize_t(ssize_t *pu, int ct) UNIQ_SORT
 
 static int cmp_size_t(const void * a, const void * b)
 {
-	return *(size_t*)a < *(size_t*)b ? -1 : *(size_t*)a > *(size_t*)b;
+	return *(const size_t*)a < *(const size_t*)b ? -1 : *(const size_t*)a > *(const size_t*)b;
 }
 void qsort_size_t(size_t *array, int ct)
 {
@@ -43,7 +43,7 @@ void qsort_size_t(size_t *array, int ct)
 }
 static int cmp_ssize_t(const void * a, const void * b)
 {
-	return *(ssize_t*)a < *(ssize_t*)b ? -1 : *(ssize_t*)a > *(ssize_t*)b;
+	return *(const ssize_t*)a < *(const ssize_t*)b ? -1 : *(const ssize_t*)a > *(const ssize_t*)b;
 }
 void qsort_ssize_t(ssize_t *array, int ct)
 {

--- a/nfq2/protocol.c
+++ b/nfq2/protocol.c
@@ -47,7 +47,7 @@ t_l7proto l7proto_from_name(const char *name)
 }
 bool l7_proto_match(t_l7proto l7proto, uint64_t filter_l7)
 {
-	return filter_l7==L7_ALL || (filter_l7 & (1ULL<<l7proto)) || (filter_l7 & (1ULL<<L7_KNOWN)) && l7proto>L7_KNOWN && l7proto<L7_LAST;
+	return (filter_l7==L7_ALL) || (filter_l7 & (1ULL<<l7proto)) || (filter_l7 & (1ULL<<L7_KNOWN)) && (l7proto>L7_KNOWN) && (l7proto<L7_LAST);
 }
 
 static const char *l7payload_name[] = {
@@ -76,7 +76,7 @@ const char *l7payload_str(t_l7payload l7)
 }
 bool l7_payload_match(t_l7payload l7payload, uint64_t filter_l7p)
 {
-	return filter_l7p==L7P_ALL || (filter_l7p & (1ULL<<l7payload)) || (filter_l7p & (1ULL<<L7P_KNOWN)) && l7payload>L7P_KNOWN && l7payload<L7P_LAST;
+	return (filter_l7p==L7P_ALL) || (filter_l7p & (1ULL<<l7payload)) || (filter_l7p & (1ULL<<L7P_KNOWN)) && (l7payload>L7P_KNOWN) && (l7payload<L7P_LAST);
 }
 bool l7_payload_str_list(uint64_t l7p, char *buf, size_t size)
 {


### PR DESCRIPTION
Fixed a few compiler/static analyzer warnings (const-correctness and operator precedence clarification). No functional changes. (cleaned-up version of the previous PR)