### PR TITLE
docs: fix doubled word in manual.en.md

### DIFF
--- a/docs/manual.en.md
+++ b/docs/manual.en.md
@@ -2229,7 +2229,7 @@ If conntrack is disabled or the packet is not valid tcp or udp, nil is returned.
 function get_source_ip(target)
 ```
 
-Get source IP (raw string) that would be used for connection the the target IP.
+Get source IP (raw string) that would be used for connection to the target IP.
 Returns nil if destination is unreachable.
 
 ```


### PR DESCRIPTION
Fixes a doubled "the the" on line 2232: "would be used for connection ~~the the~~ **to the** target IP".
